### PR TITLE
Add try/catch statement to E2.

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/compiler.lua
+++ b/lua/entities/gmod_wire_expression2/base/compiler.lua
@@ -954,3 +954,18 @@ function Compiler:InstrINCLU(args)
 
 	return { self:GetOperator(args, "include", {})[1], file }
 end
+
+function Compiler:InstrTRY(args)
+	-- args = { "try", trace, try_block, variable, catch_block }
+	self:PushPrfCounter()
+	local stmt = self:EvaluateStatement(args, 1)
+	local var_name = args[4]
+	self:PushScope()
+		self:SetLocalVariableType(var_name, "s", args)
+		local stmt2 = self:EvaluateStatement(args, 3)
+	self:PopScope()
+
+	local prf_cond = self:PopPrfCounter()
+
+	return { self:GetOperator(args, "try", {})[1], prf_cond, stmt, var_name, stmt2 }
+end

--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -33,7 +33,8 @@ Stmt7 ← (Var ("+=" / "-=" / "*=" / "/="))? Stmt8
 Stmt8 ← "local"? (Var (&"[" Index ("=" Stmt8)? / "=" Stmt8))? Stmt9
 Stmt9 ← ("switch" "(" Expr1 ")" "{" SwitchBlock)? Stmt10
 Stmt10 ← (FunctionStmt / ReturnStmt)? Stmt11
-Stmt11 ← ("#include" String)? Expr1
+Stmt11 ← ("#include" String)? Stmt12
+Stmt12 ← ("try" Block "catch" "(" Var ")" Block)? Expr1
 
 FunctionStmt ← "function" FunctionHead "(" FunctionArgs Block
 FunctionHead ← (Type Type ":" Fun / Type ":" Fun / Type Fun / Fun)
@@ -710,6 +711,32 @@ function Parser:Stmt11()
 		return self:Instruction(Trace, "inclu", Path)
 	end
 
+	return self:Stmt12()
+end
+
+function Parser:Stmt12()
+	if self:AcceptRoamingToken("try") then
+		local trace = self:GetTokenTrace()
+		local stmt = self:Block("try block")
+		if self:AcceptRoamingToken("catch") then
+			if not self:AcceptRoamingToken("lpa") then
+				self:Error("Left parenthesis (() expected after catch keyword")
+			end
+
+			if not self:AcceptRoamingToken("var") then
+				self:Error("Variable expected after left parenthesis (() in catch statement")
+			end
+			local var_name = self:GetTokenData()
+
+			if not self:AcceptRoamingToken("rpa") then
+				self:Error("Right parenthesis ()) missing, to close catch statement")
+			end
+
+			return self:Instruction(trace, "try", stmt, var_name, self:Block("catch block") )
+		else
+			self:Error("Try block must be followed by catch statement")
+		end
+	end
 	return self:Expr1()
 end
 

--- a/lua/entities/gmod_wire_expression2/base/tokenizer.lua
+++ b/lua/entities/gmod_wire_expression2/base/tokenizer.lua
@@ -177,6 +177,10 @@ function Tokenizer:NextSymbol()
 			tokenname = "void"
 		elseif self.tokendata == "#include" then
 			tokenname = "inclu"
+		elseif self.tokendata == "try" then
+			tokenname = "try"
+		elseif self.tokendata == "catch" then
+			tokenname = "catch"
 		elseif self.tokendata:match("^[ijk]$") and self.character ~= "(" then
 			tokenname, self.tokendata = "num", "1" .. self.tokendata
 		else

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -20,6 +20,7 @@ local keywords = {
 	["switch"] 	 = { [true] = true, [false] = true },
 	["case"]     = { [true] = true, [false] = true },
 	["default"]  = { [true] = true, [false] = true },
+	["catch"]    = { [true] = true, [false] = true },
 
 	-- keywords that cannot be followed by a "(":
 	["else"]     = { [true] = true },
@@ -28,6 +29,7 @@ local keywords = {
 	--["function"] = { [true] = true },
 	["return"] = { [true] = true },
 	["local"]  = { [true] = true },
+	["try"]    = { [true] = true }
 }
 
 -- fallback for nonexistant entries:


### PR DESCRIPTION
Adds a try / catch statement to E2 that allows users to catch any errors that occur inside of the block, and if so, run the catch block, setting the variable name provided to a new local variable that contains the error string.